### PR TITLE
Always preserve From: header in the input; it has been unwillingly gotten rid of.

### DIFF
--- a/ssmtp.c
+++ b/ssmtp.c
@@ -933,6 +933,7 @@ void header_save(char *str)
 		}
 #endif
 
+		have_from = True;
 #ifdef REWRITE_DOMAIN
 		if(override_from == True) {
 			if(uad != NULL) {
@@ -940,11 +941,7 @@ void header_save(char *str)
 			}
 			uad = from_strip(ht->string);
 		}
-		else {
-			return;
-		}
 #endif
-		have_from = True;
 	}
 #ifdef HASTO_OPTION
 	else if(strncasecmp(ht->string, "To:" ,3) == 0) {


### PR DESCRIPTION
I suspect this is a bug from the upstream. The bug is simple; the following,

```
$ ssmtp <<HERE
From: Moriyoshi Koizumi <mozo@mozo.jp>
Subject: test

test
HERE
```

ends up like

```
From: "MYLOGINUSERNAME" <mozo@mozo.jp>
Subject: test

test
```

unless `FromLineOverride` is set to `YES`.

The early-return effectively prevents the variable `have_from` from being set while it should be set regardless of the settings.  
