### PR TITLE
XOAUTH2 support.

### DIFF
--- a/ssmtp.c
+++ b/ssmtp.c
@@ -2061,6 +2061,26 @@ int ssmtp(char *argv[])
 
 			to64frombits(buf, (unsigned char*)auth_pass, strlen(auth_pass));
 		}
+		else if(auth_method && strcasecmp(auth_method, "xoauth2") == 0) {
+			int authbuflen;
+			char *authbuf = malloc(5 + strlen(auth_user) + 1 + 5 + 6 + 1 + strlen(auth_pass) + 2 + 1);
+			if(!authbuf) {
+				die("Out of memory");
+			}
+			outbytes += smtp_write(sock, "AUTH XOAUTH2");
+			alarm((unsigned) MEDWAIT);
+			if(smtp_read(sock, buf) != 3) {
+				comm_error = buf;
+				die("Server didn't accept AUTH XOAUTH2");
+			}
+			if(!authbuf) {
+				die("out of memory");
+			}
+			memset(buf, 0, bufsize);
+			authbuflen = sprintf(authbuf, "user=%s\1auth=Bearer %s\1\1", auth_user, auth_pass);
+			to64frombits(buf, (unsigned char*)authbuf, authbuflen);
+			free(authbuf);
+		}
 		else {
 			char *authbuf = malloc((strlen(auth_user) * 2) + strlen(auth_pass) + 3);
 			if(!authbuf) {

--- a/ssmtp.c
+++ b/ssmtp.c
@@ -2073,9 +2073,6 @@ int ssmtp(char *argv[])
 				comm_error = buf;
 				die("Server didn't accept AUTH XOAUTH2");
 			}
-			if(!authbuf) {
-				die("out of memory");
-			}
 			memset(buf, 0, bufsize);
 			authbuflen = sprintf(authbuf, "user=%s\1auth=Bearer %s\1\1", auth_user, auth_pass);
 			to64frombits(buf, (unsigned char*)authbuf, authbuflen);


### PR DESCRIPTION
This patch allows the software to be authenticated against the SMTP server that supports [XOAUTH2](https://developers.google.com/gmail/xoauth2_protocol.html) authentication mechanism.

The authentication token is supposed to be given to the `AuthPass` setting.
